### PR TITLE
Add Forward Proxy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ You also need those 3 things (their underlying machines) to have network access 
 2. the Moon cluster should have access to the FAST docker container,
 3. the FAST docker container should have access to the test app "DVWA" (see below).
 
-### Quick start
-#### Deploy DVWA
+### Quick start (run FAST as a Forward Proxy)
+#### Deploy the app under test "DVWA"
 Here we use this docker image with the app: https://hub.docker.com/r/vulnerables/web-dvwa/
 
 **Warning**: do not deploy it to any public servers.
@@ -20,8 +20,50 @@ Here we use this docker image with the app: https://hub.docker.com/r/vulnerables
 2. Open the deployed DVWA "Database Setup" page in a browser
 3. Setup DVWA app by clicking on the "Create / Reset database" button.
 
-#### Deploy FAST
+You can also use image https://hub.docker.com/r/wallarm/fast-example-dvwa-base based on the one mentioned above,
+but it is immediately ready for use without preliminary database setup.
+
+#### Deploy FAST in the Forward Proxy mode
 1. Create env file 'fast.env' with the content bellow:
+```
+#REVERSE_PROXY=false
+#WALLARM_API_HOST=us1.api.wallarm.com ## default: us1.api.wallarm.com
+#BACKEND=http://$DVWA_HOST
+WALLARM_API_TOKEN=$WALLARM_API_TOKEN
+```
+2. Replace $WALLARM_API_TOKEN with the actual FAST node token (see how to get it: https://docs.fast.wallarm.com/en/operations/create-node.html)
+3. Create a Test Run as described in https://docs.fast.wallarm.com/en/operations/create-testrun.html (select or create your Fast node and mark the "Skip following files extensions" checkbox)
+5. Run FAST docker container: `docker run --rm --name fast-test-dvwa --env-file=$(pwd)/fast.env -p 8080:8080 wallarm/fast:latest`
+
+#### Deploy Moon to Minikube
+You can omit this if you already have a Moon cluster.
+
+1. Install minikube for deploying the Moon (if you don't already have minikube) as described in https://minikube.sigs.k8s.io/docs/start/
+2. Deploy the Moon to minikube as describe here: https://aerokube.com/moon/latest/#install-minikube
+3. Run `minikube ip` to know its IP address.
+4. Optionally for convenience you can add minikube IP address to the file `/etc/hosts` with an arbitrary domain name like this: `192.168.49.2    minikube`, then you can open Moon Web UI in a browser on http://minikube:8080
+
+#### Setup and run tests
+1. Clone this repo
+2. Copy file `config.properties.example` to `config.properties` in the repository root
+3. Edit `config.properties`: modify values with actual addresses of deployed fast_proxy and minikube.
+4. Check the value of the property `fast_proxy.mode.is_reverse`: it should be `false`.
+   Generally, it should be equal to the value of the parameter `REVERSE_PROXY` in the FAST proxy config file 'fast.env'.
+5. Run the tests: `mvn clean test`.
+
+You can also set up and run the tests in an IDE as a TestNG Suite `src/test/resources/testng.xml` or directly the test class
+`src/test/java/net/dvwa/tests/DvwaTest.java`.
+An IDE can run these tests also as a Maven target, provide the command line arguments: `clean test`.
+
+#### See the results of the FAST Test Run
+1. During or after the tests running and passing you can see the FAST Test Run progress and results as described in https://docs.fast.wallarm.com/en/operations/check-testrun-status.html
+
+### Run the FAST as a Reverse Proxy
+Assume you have deployed and configured all the entities described in the Quick Start section above:
+the app under test, FAST proxy, Moon in Minikube and this repo with tests ready to run.
+
+#### Deploy FAST in the Reverse Proxy mode
+1. Create or modify env file 'fast.env' with the content bellow:
 ```
 REVERSE_PROXY=true
 #WALLARM_API_HOST=us1.api.wallarm.com ## default: us1.api.wallarm.com
@@ -30,20 +72,10 @@ WALLARM_API_TOKEN=$WALLARM_API_TOKEN
 ```
 2. Replace $DVWA_HOST with the actual domain name or IP address (and add a port if you changed it from 80 when running the DVWA docker container)
 3. Replace $WALLARM_API_TOKEN with the actual FAST node token (see how to get it: https://docs.fast.wallarm.com/en/operations/create-node.html)
-4. Create a Test Run as described here: https://docs.fast.wallarm.com/en/operations/create-testrun.html (select or create your Fast node and mark the "Skip following files extensions" checkbox)
+4. Create a Test Run as described in https://docs.fast.wallarm.com/en/operations/create-testrun.html (select or create your Fast node and mark the "Skip following files extensions" checkbox)
 5. Run FAST docker container: `docker run --rm --name fast-test-dvwa --env-file=$(pwd)/fast.env -p 8080:8080 wallarm/fast:latest`
 
-#### Deploy Moon on Minikube
-You can omit this if you already have a Moon cluster.
-
-1. Install minikube for deploying the Moon (if you don't already have minikube) as described here: https://minikube.sigs.k8s.io/docs/start/
-2. Deploy the Moon to minikube as describe here: https://aerokube.com/moon/latest/#install-minikube
-3. Run `minikube ip` to know its IP address.
-4. Optionally for convenience you can add minikube IP address to the file `/etc/hosts` with an arbitrary domain name like this: `192.168.49.2    minikube`, then you can open Moon Web UI in a browser on http://minikube:8080
-
-#### Run tests
-1. Clone this repo
-2. Copy file `config.properties.example` to `config.properties` in the repository root
-3. Edit `config.properties`: modify values with actual addresses of deployed fast_proxy and minikube.
-4. Run the tests: `mvn test` (also, you can open the project in any IDE and run the tests in it)
-
+#### Setup and run tests
+1. Edit `config.properties`: set the value of the property `fast_proxy.mode.is_reverse` to `true`: it should be equal to the value of the parameter
+   `REVERSE_PROXY` in the FAST proxy config file 'fast.env'.
+5. Run the tests: `mvn clean test` (also, you can open the project in any IDE and run the tests in it)

--- a/config.properties.example
+++ b/config.properties.example
@@ -1,10 +1,15 @@
 # Config file for tests settings
 # About the format: https://en.wikipedia.org/wiki/.properties
 
+# Application under test base URL
+target_app.base_url=http://target_webapp_host
+
 # FAST proxy URL
 fast_proxy.base_url=http://fast_proxy:8080
+
+# FAST proxy mode: 'reverse' if 'true', 'forward' otherwise
+fast_proxy.mode.is_reverse=false
 
 # Selenium server (localhost, Selenium Grid, Selenoid or Moon).
 # Usually you need to change only hostname and keep port and path as is: ":4444/wd/hub"
 selenium.server_url=http://minikube:4444/wd/hub
-

--- a/src/test/java/net/dvwa/pages/AbstractPage.java
+++ b/src/test/java/net/dvwa/pages/AbstractPage.java
@@ -4,8 +4,15 @@ import net.dvwa.util.Config;
 import net.dvwa.util.SharedWebDriver;
 
 public class AbstractPage {
-  protected static final String BASE_URL = (String) Config.getConfig()
-          .getOrDefault("fast_proxy.base_url", "http://fast_proxy:8080");;
+  protected static final String TARGET_APP_BASE_URL;
+  static {
+    if (Boolean.parseBoolean(Config.get("fast_proxy.mode.is_reverse"))) {
+      TARGET_APP_BASE_URL = Config.get("fast_proxy.base_url");
+    } else {
+      TARGET_APP_BASE_URL = Config.get("target_app.base_url");
+    }
+  }
+
   protected final SharedWebDriver driver = SharedWebDriver.getSharedWebDriver();
 
   public <T extends AbstractPage> T newPage(Class<T> clazz) {
@@ -19,7 +26,7 @@ public class AbstractPage {
   }
 
   public String getBaseUrl() {
-    return BASE_URL;
+    return TARGET_APP_BASE_URL;
   }
 
   public String getCurrentPageUrl() {

--- a/src/test/java/net/dvwa/pages/LoginPage.java
+++ b/src/test/java/net/dvwa/pages/LoginPage.java
@@ -5,7 +5,7 @@ import org.openqa.selenium.By;
 public class LoginPage extends AbstractPage {
 
   public LoginPage open() {
-    driver.get(BASE_URL);
+    driver.get(TARGET_APP_BASE_URL);
     driver.waitForPageToLoad();
     return this;
   }

--- a/src/test/java/net/dvwa/tests/DvwaTest.java
+++ b/src/test/java/net/dvwa/tests/DvwaTest.java
@@ -1,9 +1,9 @@
 package net.dvwa.tests;
 
-import org.testng.annotations.Test;
 import net.dvwa.pages.LoginPage;
 import net.dvwa.pages.MainPage;
 import net.dvwa.pages.SqliPage;
+import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,8 +13,8 @@ public class DvwaTest extends AbstractTest {
   public void openLoginPage() {
     LoginPage loginPage = new LoginPage().open();
     assertThat(loginPage.getCurrentPageUrl()).contains(loginPage.getBaseUrl());
-    assertThat(loginPage.getTitle()).contains("Login :: Damn Vulnerable Web Application");
     assertThat(loginPage.getPageSource()).contains("href=\"http://www.dvwa.co.uk/\"");
+    assertThat(loginPage.getTitle()).contains("Login :: Damn Vulnerable Web Application");
   }
 
   @Test(dependsOnMethods = { "openLoginPage" })

--- a/src/test/java/net/dvwa/util/Config.java
+++ b/src/test/java/net/dvwa/util/Config.java
@@ -2,16 +2,18 @@ package net.dvwa.util;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Map;
 import java.util.Properties;
 
 public class Config {
     private static final Properties properties = new Properties();
+    private static Map<String, String> items = null;
 
     private static void readConfig() throws IOException {
         properties.load(new FileInputStream("config.properties"));
     }
 
-    public static Properties getConfig() {
+    private static Properties getConfig() {
         if (properties.size() == 0) {
             try {
                 readConfig();
@@ -20,5 +22,12 @@ public class Config {
             }
         }
         return properties;
+    }
+
+    public static String get(String key) {
+        if (items == null) {
+            items = (Map) getConfig();
+        }
+        return items.get(key);
     }
 }

--- a/src/test/java/net/dvwa/util/SharedWebDriver.java
+++ b/src/test/java/net/dvwa/util/SharedWebDriver.java
@@ -17,9 +17,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class SharedWebDriver extends RemoteWebDriver {
   private static final ThreadLocal<SharedWebDriver> WEB_DRIVER_HOLDER = new ThreadLocal<>();
-  private static final String SELENIUM_SERVER_URL_DEFAULT = "http://minikube:4444/wd/hub";
-  private static final String SELENIUM_SERVER_URL = (String) Config.getConfig().getOrDefault(
-          "selenium.server_url", SELENIUM_SERVER_URL_DEFAULT);
+  private static final String SELENIUM_SERVER_URL = Config.get("selenium.server_url");
   private static final long FIND_ELEMENT_DEFAULT_TIMEOUT = 10;
   private static final long SCRIPT_DEFAULT_TIMEOUT = 30;
   private static final long PAGE_LOAD_DEFAULT_TIMEOUT = 60;
@@ -60,6 +58,14 @@ public class SharedWebDriver extends RemoteWebDriver {
     options.addArguments("--start-maximized");
     options.addArguments("--disable-gpu");
     options.addArguments("--disable-notifications");
+
+    Boolean isReverseMode = Boolean.parseBoolean(Config.get("fast_proxy.mode.is_reverse"));
+    if (!isReverseMode) {
+      Proxy proxy = new Proxy();
+      proxy.setHttpProxy(Config.get("fast_proxy.base_url"));
+      options.setCapability("proxy", proxy);
+    }
+
     capabilities.setCapability(ChromeOptions.CAPABILITY, options);
 
     return capabilities;


### PR DESCRIPTION
Add ability to run the tests via a forward proxy and describe how to run FAST in this mode. Change the FAST proxy mode in the Quick Start guide from reverse to forward as it's a little easier.